### PR TITLE
Fix leave event omitting target

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,7 +343,11 @@ var createObj = {
               '@id': 'irc://' + object.nickname + '@' + this.credentials.object.server,
               displayName: object.nickname
             },
-            target: {},
+            target: {
+              '@type': 'room',
+              '@id': 'irc://' + this.credentials.object.server + '/' + object.channel,
+              displayName: object.channel
+            },
             object: {
               '@type': 'message',
               content: 'user has quit'

--- a/index.js
+++ b/index.js
@@ -426,7 +426,7 @@ var createObj = {
  *   },
  *   target: {
  *     '@id': 'irc://irc.freenode.net/sockethub',
- *     '@type': 'chatroom',
+ *     '@type': 'room',
  *     displayName: '#sockethub'
  *   },
  *   object: {}
@@ -469,7 +469,7 @@ IRC.prototype.join = function (job, done) {
  *   },
  *   target: {
  *     '@id': 'irc://irc.freenode.net/remotestorage',
- *     '@type': 'chatroom',
+ *     '@type': 'room',
  *     displayName: '#remotestorage'
  *   },
  *   object: {}
@@ -512,7 +512,7 @@ IRC.prototype.leave = function (job, done) {
  *    },
  *    target: {
  *      '@id': 'irc://irc.freenode.net/remotestorage',
- *      '@type': 'chatroom',
+ *      '@type': 'room',
  *      displayName: '#remotestorage'
  *    },
  *    object: {
@@ -563,7 +563,7 @@ IRC.prototype.send = function (job, done) {
  *   },
  *   target: {
  *     '@id': 'irc://irc.freenode.net/sockethub',
- *     '@type': 'chatroom',
+ *     '@type': 'room',
  *     displayName: '#sockethub'
  *   },
  *   object: {
@@ -663,7 +663,7 @@ IRC.prototype.update = function (job, done) {
  *    },
  *    target: {
  *      '@id': 'irc://irc.freenode.net/sockethub',
- *      '@type': 'chatroom',
+ *      '@type': 'room',
  *      displayName: '#sockethub'
  *    },
  *    object: {
@@ -678,7 +678,7 @@ IRC.prototype.update = function (job, done) {
  *    '@type': 'observe',
  *    actor: {
  *      '@id': 'irc://irc.freenode.net/sockethub',
- *      '@type': 'chatroom',
+ *      '@type': 'room',
  *      displayName: '#sockethub'
  *    },
  *    target: {},

--- a/index.js
+++ b/index.js
@@ -238,9 +238,9 @@ var createObj = {
             displayName: object.topicBy
           },
           target: {
-            '@type': 'person',
-            '@id': 'irc://' + object.topicBy + '@' + this.credentials.object.server,
-            displayName: object.topicBy
+            '@type': 'room',
+            '@id': 'irc://' + this.credentials.object.server + '/' + object.channel,
+            displayName: object.channel
           },
           object: {
             '@type': 'topic',

--- a/test/24-irc-suite.js
+++ b/test/24-irc-suite.js
@@ -111,7 +111,7 @@ define(['require'], function (require) {
             actor: env.actor,
             object: {
               '@type': 'topic',
-              displayName: 'welcome to unit testing, enjoy your stay - the management'
+              topic: 'welcome to unit testing, enjoy your stay - the management'
             },
             target: env.target.sockethub
           },

--- a/test/24-irc-suite.js
+++ b/test/24-irc-suite.js
@@ -27,22 +27,21 @@ define(['require'], function (require) {
       env.platform = new Platform(env.session);
 
       env.actor = {
-        objectType: 'person',
-        id: 'irc://testingham@irc.example.com',
+        '@type': 'person',
+        '@id': 'irc://testingham@irc.example.com',
         displayName:'testingham'
       };
 
       env.newActor = {
-        objectType: 'person',
-        id: 'irc://testler@irc.example.com',
+        '@type': 'person',
+        '@id': 'irc://testler@irc.example.com',
         displayName:'testler'
       };
-
 
       env.credentials = {
         actor: env.actor,
         object: {
-          objectType: 'credentials',
+          '@type': 'credentials',
           nick: 'testingham',
           server: 'irc.example.com'
         }
@@ -65,13 +64,13 @@ define(['require'], function (require) {
 
       env.target = {
         sockethub: {
-          objectType: 'room',
-          id: 'irc://irc.example.com/sockethub',
+          '@type': 'room',
+          '@id': 'irc://irc.example.com/sockethub',
           displayName: '#sockethub'
         },
         remotestorage: {
-          objectType: 'room',
-          id: 'irc://irc.example.com/remotestorage',
+          '@type': 'room',
+          '@id': 'irc://irc.example.com/remotestorage',
           displayName: '#remotestorage'
         }
       };
@@ -90,7 +89,7 @@ define(['require'], function (require) {
         send: {
           actor: env.actor,
           object: {
-            objectType: 'message',
+            '@type': 'message',
             content: 'hello'
           },
           target: env.target.sockethub
@@ -103,7 +102,7 @@ define(['require'], function (require) {
         observe: {
           actor: env.actor,
           object: {
-            objectType: 'attendance'
+            '@type': 'attendance'
           },
           target: env.target.sockethub
         },
@@ -111,7 +110,7 @@ define(['require'], function (require) {
           topic: {
             actor: env.actor,
             object: {
-              objectType: 'topic',
+              '@type': 'topic',
               displayName: 'welcome to unit testing, enjoy your stay - the management'
             },
             target: env.target.sockethub
@@ -126,9 +125,9 @@ define(['require'], function (require) {
       // schema
       env.schema = env.platform.schema;
 
-      // verbs
-      env.verbs = env.platform.schema.messages.properties.verb.enum;
-      test.assertAnd(env.verbs, [ 'update', 'join', 'leave', 'send', 'observe' ]);
+      // types
+      env.types = env.schema.messages.properties['@type'].enum;
+      test.assertAnd(env.types, [ 'update', 'join', 'leave', 'send', 'observe', 'announce' ]);
 
       env.api = IRCFactory.Api();
       test.assertTypeAnd(env.api, 'object');
@@ -164,8 +163,7 @@ define(['require'], function (require) {
       {
         desc: "set credentials",
         run: function (env, test) {
-          console.log('credentials: ', env.credentials);
-          env.session.store.save(env.actor.id,
+          env.session.store.save(env.actor['@id'],
                                  env.credentials, function () {
                                  test.done();
                                 });


### PR DESCRIPTION
Was actually correct for join, but leave just had a hardcoded empty target set.

This branch is based off of the one for #9.