### PR TITLE
Fix leave event

### DIFF
--- a/index.js
+++ b/index.js
@@ -733,7 +733,7 @@ IRC.prototype.__listeners = {
         debug('skipping reconnect as we are already disconnected. for ' + this.id);
       }
     } else if ((typeof object.nickname === 'string') &&
-              (typeof object.target === 'undefined') &&
+              (typeof object.channel === 'undefined') &&
               (typeof object.capabilities !== 'object')) {
       // QUIT
       debug('received quit ' + object);
@@ -770,7 +770,7 @@ IRC.prototype.__listeners = {
     } else if ((typeof object.channel === 'string') &&
               (object.raw.indexOf(' PART ') >= 0)) {
       // leave
-      this.scope.debug('received leave: ' + object.nickname + ' -> ' + object.target);
+      this.scope.debug('received leave: ' + object.nickname + ' -> ' + object.channel);
       this.scope.send({
         '@type': 'leave',
         actor: {
@@ -780,8 +780,8 @@ IRC.prototype.__listeners = {
         },
         target: {
           '@type': 'room',
-          '@id': 'irc://' + this.credentials.object.server + '/' + object.target,
-          displayName: object.target
+          '@id': 'irc://' + this.credentials.object.server + '/' + object.channel,
+          displayName: object.channel
         },
         object: {
           '@type': 'message',

--- a/index.js
+++ b/index.js
@@ -643,7 +643,7 @@ IRC.prototype.__listeners = {
               (typeof object.message === 'string')) {
       // message
       if (! object.nickname) {
-        this.scope.debug('received UNKNOWN: ' + object);
+        this.scope.debug('received UNKNOWN:', object);
       } else {
         var msg_prefix = ':' + object.nickname + '!' + object.username + '@' + object.hostname;
         var type = 'message';
@@ -721,7 +721,7 @@ IRC.prototype.__listeners = {
               (typeof object.time === 'string') &&
               (typeof object.raw === 'object')) {
       // registered
-      debug('registered! ' +  object);
+      debug('registered!', object);
     } else if ((object.reconnecting === true) &&
               (typeof object.attempts === 'number')) {
       // disconected, reconnecting
@@ -736,7 +736,7 @@ IRC.prototype.__listeners = {
               (typeof object.channel === 'undefined') &&
               (typeof object.capabilities !== 'object')) {
       // QUIT
-      debug('received quit ' + object);
+      debug('received quit', object);
       var quitter = object.kicked || object.nickname;
       var msg = (typeof object.kicked === 'string') ? 'user has been kicked' : 'user has quit';
 

--- a/test/incoming-data.js
+++ b/test/incoming-data.js
@@ -54,6 +54,36 @@ module.exports = [
     }
   },
   {
+    name: 'leave',
+    input: {
+      nickname: 'sandwich',
+      username: '~sandwich',
+      hostname: '87.78.135.102',
+      channel: '#sockethub',
+      message: '',
+      time: '2017-05-09T22:47:21.137Z',
+      raw: ':sandwich!~sandwich@87.78.135.102 PART #sockethub'
+    },
+    output: {
+      '@type': 'leave',
+      actor: {
+        '@type': 'person',
+        '@id': 'irc://sandwich@irc.freenode.net',
+        displayName: 'sandwich'
+      },
+      target: {
+        '@id': 'irc://irc.freenode.net/#sockethub',
+        '@type': 'room',
+        displayName: '#sockethub'
+      },
+      object: {
+        '@type': 'message',
+        content: 'user has left the channel'
+      },
+      published: '2017-05-09T22:47:21.137Z'
+    }
+  },
+  {
     name: 'join',
     input: { nickname: 'donut',
       username: '~donut',


### PR DESCRIPTION
When another user leaves a channel, it was handled and sent to the client as a `quit` event instead of `leave`, because it was checking for and using `object.target` instead of `object.channel`.

I also changed some of the `debug` statements to log the actual objects' content instead of just logging `[Object object]`.